### PR TITLE
Ignore main function for async postfix

### DIFF
--- a/ZoneRV.Analyzer.Tests/PoorNameTests/AsyncNameTests.cs
+++ b/ZoneRV.Analyzer.Tests/PoorNameTests/AsyncNameTests.cs
@@ -16,6 +16,33 @@ namespace ZoneRV.Analyzer.Tests.PoorNameTests;
 public class AsyncNameTests
 {
     [Fact]
+    public async Task IgnoreMain()
+    {
+        const string text = @"
+using System.Threading.Tasks;
+
+public class Program
+{
+    async Task Main()
+    {
+        await Task.Delay(100);
+    }
+}";
+        
+
+        await new CSharpAnalyzerTest<PoorNameAnalyzer, XUnitVerifier>
+            {
+                TestState =
+                {
+                    Sources             = { text },
+                    ExpectedDiagnostics = {},
+                    ReferenceAssemblies = ReferenceAssemblies.Net.Net90
+                }
+            }
+           .RunAsync();
+    }
+    
+    [Fact]
     public async Task CheckVariableNames()
     {
         const string text = @"

--- a/ZoneRV.Analyzer/PoorName/PoorNameAnalyzer.AsyncMethod.cs
+++ b/ZoneRV.Analyzer/PoorName/PoorNameAnalyzer.AsyncMethod.cs
@@ -25,6 +25,9 @@ public partial class PoorNameAnalyzer
         var isAsyncBySymbol = symbol?.IsAsync == true;
 
         var isAsync = isAsyncBySyntax || isAsyncBySymbol;
+        
+        if(methodDeclarator.Identifier.ValueText.Equals("Main"))
+            return; // Ignore program main
 
         if (!methodDeclarator.Identifier.ValueText.EndsWith("async", StringComparison.OrdinalIgnoreCase) && isAsync)
         {

--- a/ZoneRV.Analyzer/ZoneRV.Analyzer.csproj
+++ b/ZoneRV.Analyzer/ZoneRV.Analyzer.csproj
@@ -22,7 +22,7 @@
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <NoPackageAnalysis>true</NoPackageAnalysis>
         <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-        <Version>1.6.2</Version>
+        <Version>1.6.3</Version>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Ignore `Main` method in async naming convention check, add corresponding test, and bump version to 1.6.3